### PR TITLE
Add support for custom params in Custom Validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ by version `4.2.4` in reform-examples
 
 ## Quick Start
 
-Reform provides a very minimal and hopefully unobstrusive API that _mounts_ over regular Form Handling in React.
+Reform provides a very minimal and hopefully unobtrusive API that _mounts_ over regular Form Handling in React.
 Checkout React Controlled Components documentation to see the original API.
 
 
@@ -214,7 +214,7 @@ For now, the examples are in a separate [Repo](https://github.com/franleplant/re
 > Documentation, docs
 
 ## `<Reform/>`
-> form, reform, component, entry point, onSubmit, top level api
+> **Keywords:** form, reform, component, entry point, onSubmit, top level api
 
 This is the entry point to the lib. The way to use it is as follow:
 
@@ -245,7 +245,7 @@ through `onSubmit` but you are free to do the way you want to.
 
 Common interface for reporting errors for a particular `Control`.
 
-Type Definition
+###### Type Definition
 ```typescript
 type Errors = {
   isValid: () => boolean;
@@ -325,7 +325,7 @@ function handleChange(control, event) {...}
 ```
 
 
-Type definition:
+###### Type definition
 ```typescript
 type Control = {
   // It's calculated via `getValues` (see data-reform)
@@ -401,7 +401,7 @@ Note that `errors.required` will be `false` because the control has a value so i
 > **Keywords:** form state, formState, isValid, access to all controls
 
 You can use this object to access all the controls in the form.
-You use typically use it to prevent the form from being submited if it's invalid
+You use typically use it to prevent the form from being submitted if it's invalid
 and to update your Form Component error state.
 
 
@@ -412,8 +412,7 @@ function handleSubmit(form, event) {...}
 ```
 
 
-This is the type definition
-
+### Type Definition
 ```typescript
 type Form = {
   [fieldName: string]: Control;
@@ -424,8 +423,8 @@ type Form = {
 ```
 
 
-###### Example
-This is an example of how to check form validity before call to a hipotetical API submitting the form:
+###### :black_large_square: Example
+This is an example of how to check form validity before call to a hypothetical API submitting the form:
 
 ```javascript
 class MyComponent extends React.Component {
@@ -469,7 +468,7 @@ Use it to:
 - Pass whatever data you need to custom validators via `params`
 
 
-It has the following signature:
+###### Type Definition
 ```typescript
 type DataReform = {
 
@@ -508,23 +507,8 @@ from the onChange arguments.
 - `control` is the current state of the `control` so you have all the data of that control available such as the `inputType` for example.
 
 
-You can force a Custom Component to be considered by `Reform` as a `checkbox` or a `radio` like this:
 
-```javascript
-<MyCustomComponent
-  name="myField"
-  value={this.state.fields.myField}
-  onChange={...}
-  data-reform={
-    inputType:"checkbox"
-  }
-/>
-```
-
-> NOTE We already work well with `react-bootstrap` so no extra verbosity needed there. Also, the plan is to support
-any view libraries' Custom Components so PR us or create an issue for anything lacking.
-
-###### Example
+###### :black_large_square: Example
 
 In the following example we use it to tell Reform that it should validate
 this control with a custom ad hoc validator called `myRule1` and also we tell
@@ -553,6 +537,30 @@ This gives you the flexibility to hook basically anything that has the three mag
   :black_large_square:
 </h6>
 
+###### :black_large_square: Example: Forcing Custom components as `checkbox` or `radio`
+
+You can force a Custom Component to be considered by `Reform` as a `checkbox` or a `radio` like this:
+
+```javascript
+<MyCustomComponent
+  name="myField"
+  value={this.state.fields.myField}
+  onChange={...}
+  data-reform={
+    inputType:"checkbox"
+  }
+/>
+```
+
+> NOTE We already work well with `react-bootstrap` so no extra verbosity needed there. Also, the plan is to support
+any view libraries' Custom Components so PR us or create an issue for anything lacking.
+
+
+
+<h6 align="right">
+  :black_large_square:
+</h6>
+
 ## Custom Validators
 > **Keywords:** custom validators, validate, ad hoc, global validators, async validators
 
@@ -567,14 +575,14 @@ Reform supports two forms of custom validators: Ad Hoc and Global.
 
 Validators are just functions with the following signature:
 
-Type Definition
+###### Type Definition
 ```typescript
 CustomValidator: (control: Control, formState: FormState) => boolean;
 ```
 
 If a validator returns `true` then that means that there is an error.
 
-###### Example
+###### :black_large_square: Example: writing a custom validator
 
 ```javascript
 function customMinLength(control, formState) {
@@ -590,19 +598,33 @@ function customMinLength(control, formState) {
 }
 ```
 
-
 > FormState gives you access to the rest of the form controls, so you can implement things such
 as password verification pretty easily
+
+
+In the following sections we are going to see how to use it.
+
 
 <h6 align="right">
   :black_large_square:
 </h6>
 
+
+**Important**
+
+If you add a custom validator with the same name as a Native Validator, that means, you are trying to
+overwrite a Native Validator then `Reform` is going to throw an error.
+
 ### Ad Hoc Custom Validators
+
+> Ad Hoc means _created or done for a particular purpose as necessary._
+
 
 This type of custom validators are defined in place of the control using it.
 They are similar to anonymous functions, they are intended for one time use.
 
+
+###### :black_large_square: Example
 
 Let's use `CustomMinLength` defined before as an Ad Hoc Custom Validator
 
@@ -625,8 +647,10 @@ Let's use `CustomMinLength` defined before as an Ad Hoc Custom Validator
 </Reform>
 
 ```
+<h6 align="right">
+  :black_large_square:
+</h6>
 
-> Ad Hoc means _created or done for a particular purpose as necessary._
 
 
 > While you could create a simple function that acts as custom validator and pass it around
@@ -639,6 +663,8 @@ and use Global Validators instead.
 When building a big application you will probably want to create a reusable
 pool of Custom Validators that are related to your app's domain.
 Reform let's you define new validators and re-use them.
+
+###### :black_large_square: Example
 
 Let's add `customMinLength` as a Global Validator
 
@@ -672,6 +698,10 @@ Now you can use it everywhere via `data-reform`
 
 > Note that instead of passing a function to `customMinLength` we are passing a simple boolean, 
 Reform will then look for a previously defined validator with that rule.
+
+<h6 align="right">
+  :black_large_square:
+</h6>
 
 
 
@@ -799,7 +829,7 @@ class Login extends Component {
 }
 ```
 
-There's nothing special with this but it's just a more succint way of doing the two way data bindings.
+There's nothing special with this but it's just a more succinct way of doing the two way data bindings.
 
 This:
 
@@ -828,12 +858,15 @@ Turns to this:
 />
 ```
 
+
+You could even go further and make it work with Checkboxes and Radios
+
 ### How to display errors?
 
 As you've already seen, errors should be stored someplace in the state. We've been using
 `this.state.errors`.
 
-There are several ways of display erorrs, most of these techniques are not `Reform` specific so feel
+There are several ways of display errors, most of these techniques are not `Reform` specific so feel
 free to use your React knowledge the best you can.
 
 The simplest most verbose way is this one
@@ -851,7 +884,7 @@ The simplest most verbose way is this one
 
 > NOTE: this assumes you initialized `this.state.errors.myField = {}` otherwise you would also have to check if `this.state.errors.myField` is null.
 
-The problem with this approach is the ternary operation, the verbosity, and the ugglyness, but we can do better, how? Just use React components!
+The problem with this approach is the ternary operation, the verbosity, and the ugliness, but we can do better, how? Just use React components!
 
 ```javascript
 
@@ -909,7 +942,7 @@ const Try = ({exp, children}) => {
 
 I though about creating a lib with this Component but I rather explain you how it works rather than ship it and maintain it.
 
-the magic that `Try` does is really simple, and abstracts this:
+The magic that `Try` does is really simple, and abstracts this:
 
 ```javascript
 {
@@ -919,7 +952,7 @@ the magic that `Try` does is really simple, and abstracts this:
 ```
 
 So you basically avoid those nasty checks and also abstract them and also avoid the need to initialize your
-error state and since you have full control of the `Try` component you can tunne it to your particular needs.
+error state and since you have full control of the `Try` component you can tune it to your particular needs.
 
 
 # Internals
@@ -929,14 +962,14 @@ In this section we are going to explain how `Reform` works from the inside.
 This documentation is useful to 
 
 - Contributors that need to understand the core ideas of `Reform`
-- Users that want to desmistify the inner workings of `Reform`. It's not at all Black Magic.
+- Users that want to demystify the inner workings of `Reform`. It's not at all Black Magic.
 
 ## React Controlled Components
 
 `Reform` mounts and enhances React Controlled Components, which is basically another way of naming Two Way Data Binding (2WDB).
 
 I believe that the main reason not to call this pattern 2WDB is because it's much less magical,
-you always clearly know what are the ways the data flow from the **View** to the **Model** and viceversa.
+you always clearly know what are the ways the data flow from the **View** to the **Model** and vice versa.
 
 
 <h3 align="center">
@@ -987,7 +1020,7 @@ This is all fine and both React and Reform work well with this.
 
 ## Reform Controlled Components
 
-We've basically explained everything that Reforms does, the only detail is that `Reform` highjacks the **View -> Model** flow
+We've basically explained everything that Reforms does, the only detail is that `Reform` hijacks the **View -> Model** flow
 and adds **validation** data to the newValue or `event` that the **View** emits in the form of the `control` object.
 
 
@@ -1084,9 +1117,9 @@ a `change` event we simply run all validators associated with those rules and as
 So, basically, all `validationRules` have a `validator` function associated with them that basically return `true` if the Control does not fulfill that validation.
 
 Native validators are exactly the same as custom validators, they use the same API and return types, the only difference is that Reform
-already includes them wether custom validators are writen by the user.
+already includes them whether custom validators are written by the user.
 
-Native validators are writen to try to comply with w3c spec.
+Native validators are written to try to comply with w3c spec.
 
 Native validators often do different validations depending on the type of the Input or Control. For example the `min` native validator
 operates differently on an `input` `type="number"` and a `type="date"`.

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ This is the entry point to the lib. The way to use it is as follow:
 ```
 This Component does not receive any props, that's by design so we keep the interface as minimal and simple as possible.
 
-`Reform` will hook **all components that have a `name`, `value` and `onChange` props** that are children of it, no more no less.
+`Reform` will hook **all components that have the magical props `name`, `value` and `onChange`** that are children of it, no more no less.
 
 
 > If you do not provide the `onSubmit` in your `<form>` element then you should manually set `noValidate`
@@ -412,7 +412,7 @@ function handleSubmit(form, event) {...}
 ```
 
 
-### Type Definition
+###### Type Definition
 ```typescript
 type Form = {
   [fieldName: string]: Control;

--- a/README.md
+++ b/README.md
@@ -261,10 +261,9 @@ type Errors = {
 
 ```
 
-#### Example 1
-
+<hr/>
+#### Example: what it looks like in practice
 ```javascript
-
 errors: {
   required: true,
   myCustomRule: false,
@@ -276,9 +275,10 @@ errors: {
 - each `validationRuleKey` is always related to a rule. So, for example, there's a rule (function) called `required` (built-in) which will be evaluated every time the input changes value and it's result will be stored in errors. 
 
 > Always `errors[validationRuleKey]` will be `true` if there is an **error**
+<hr/>
 
-
-#### Example 2: errors and styling
+<hr/>
+###### Example: errors and styling
 
 Suppose our error state is initialized like this
 
@@ -309,9 +309,10 @@ Then you can style Controls accordingly like so:
 
 See how useful the `isInvalid` attribute is, because it works well with empty objects.
 
+<hr/>
 
 ### `Control`
-> form control, form input, custom controls, field, input, select, textarea, radio, checkbox
+> **Keywords:** form control, form input, custom controls, field, input, select, textarea, radio, checkbox
 
 You access it from the `onChange` handlers like this:
 
@@ -320,12 +321,14 @@ function handleChange(control, event) {...}
 ```
 
 
-This is the type definition (in pseudo typescript)
-
+Type definition:
 ```typescript
 type Control = {
+  // It's calculated via `getValues` (see data-reform)
   value: string | number | any;
+  
   checked: boolean;
+  
   errors: Errors;
   
   isValid: () => boolean;
@@ -336,7 +339,7 @@ type Control = {
     // using built-in standard rules (require, min, minLength, et al)
     [validationRuleKey: string]: boolean | Function;
   };
-
+  
   // This function tells Reform how to get the value of a Control Element
   // from the arguments of the onChange event handler.
   // Check `data-form` section for more information
@@ -347,11 +350,19 @@ type Control = {
   
   // The React element type
   elementType: string | Function;
+  
+  // Free space for users to pass custom data to custom Validators
+  params: any;
 }
-
 ```
 
+> **Important** `Control` should be considered a **read only** data structure. 
+The correct place to modify it is via `data-reform` and special props like native validator props
+and the three magical `name`, `value`, `onChange`.
 
+
+<hr/>
+###### Example
 
 If you have a field like this
 ```javascript
@@ -379,6 +390,7 @@ control = {
 ```
 
 Note that `errors.required` will be `false` because the control has a value so it's not in error state.
+<hr/>
 
 ### `Form`
 > **Keywords:** form state, formState, isValid, access to all controls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Reform [![Build Status](https://travis-ci.org/franleplant/reform.svg?branch=master)](https://travis-ci.org/franleplant/reform) [![Coverage Status](https://coveralls.io/repos/github/franleplant/reform/badge.svg?branch=master)](https://coveralls.io/github/franleplant/reform?branch=master)
 
+
+
 Form validation library for React
 
 > This lib is in Alpha stage
@@ -260,7 +262,6 @@ type Errors = {
 };
 ```
 
-<hr/>
 ###### Example: what it looks like in practice
 ```javascript
 errors: {
@@ -275,10 +276,10 @@ errors: {
 
 > Always `errors[validationRuleKey]` will be `true` if there is an **error**
 
+<h6 align="right">
+  :black_large_square:
+</h6>
 
-<hr/>
-
-<hr/>
 ###### Example: errors and styling
 
 Suppose our error state is initialized like this
@@ -309,8 +310,9 @@ Then you can style Controls accordingly like so:
 ```
 
 See how useful the `isInvalid` attribute is, because it works well with empty objects.
-
-<hr/>
+<h6 align="right">
+  :black_large_square:
+</h6>
 
 ## `Control`
 > **Keywords:** form control, form input, custom controls, field, input, select, textarea, radio, checkbox
@@ -362,7 +364,6 @@ The correct place to modify it is via `data-reform` and special props like nativ
 and the three magical `name`, `value`, `onChange`.
 
 
-<hr/>
 ###### Example
 
 If you have a field like this
@@ -391,7 +392,9 @@ control = {
 ```
 
 Note that `errors.required` will be `false` because the control has a value so it's not in error state.
-<hr/>
+<h6 align="right">
+  :black_large_square:
+</h6>
 
 ## `Form`
 > **Keywords:** form state, formState, isValid, access to all controls
@@ -420,7 +423,6 @@ type Form = {
 ```
 
 
-<hr/>
 ###### Example
 This is an example of how to check form validity before call to a hipotetical API submitting the form:
 
@@ -449,7 +451,9 @@ class MyComponent extends React.Component {
   }
 }
 ```
-<hr/>
+<h6 align="right">
+  :black_large_square:
+</h6>
 
 ## `data-reform`
 > **Keywords:** configuration, config, manual, customization, custom validators, get value, parse
@@ -519,7 +523,6 @@ You can force a Custom Component to be considered by `Reform` as a `checkbox` or
 > NOTE We already work well with `react-bootstrap` so no extra verbosity needed there. Also, the plan is to support
 any view libraries' Custom Components so PR us or create an issue for anything lacking.
 
-<hr/>
 ###### Example
 
 In the following example we use it to tell Reform that it should validate
@@ -545,7 +548,9 @@ This gives you the flexibility to hook basically anything that has the three mag
   }}
 />
 ```
-<hr/>
+<h6 align="right">
+  :black_large_square:
+</h6>
 
 ## Custom Validators
 > **Keywords:** custom validators, validate, ad hoc, global validators, async validators
@@ -568,7 +573,6 @@ CustomValidator: (control: Control, formState: FormState) => boolean;
 
 If a validator returns `true` then that means that there is an error.
 
-<hr/>
 ###### Example
 
 ```javascript
@@ -589,8 +593,9 @@ function customMinLength(control, formState) {
 > FormState gives you access to the rest of the form controls, so you can implement things such
 as password verification pretty easily
 
-
-<hr/>
+<h6 align="right">
+  :black_large_square:
+</h6>
 
 ### Ad Hoc Custom Validators
 

--- a/README.md
+++ b/README.md
@@ -438,36 +438,44 @@ class MyComponent extends React.Component {
 
 
 ### `data-reform`
-> configuration, config, manual, customization, custom validators, get value, parse
+> **Keyword:** configuration, config, manual, customization, custom validators, get value, parse
 
 `data-reform` is a custom prop used to config reform on a particular form control.
 
 Use it to:
 
-- Define Custom Validators (ad hoc or global)
-- Custom `getValue`
-- Force a Component to be considered a `checkbox` or a `radio`
+- Define Custom Validators (ad hoc or global) via `validationRules`
+- Custom `getValue` via `getValue`
+- Force a Component to be considered a `checkbox` or a `radio` via `inputType`
+- Pass whatever data you need to custom validators via `params`
 
 
-In the following example we use it to tell Reform that it should validate
-this control with a custom ad hoc validator called `myRule1` and also we tell
-Reform that the value that this input emits on `change` should be calculated as
-`event.target.value.toUpperCase()`.
+It has the following signature:
+```typescript
+type DataReform = {
 
-This gives you the flexibility to hook basically anything that has the three magical props:
-`name`, `value` and `onChange`.
+  // Use it to define the way you calculate the control value
+  // from the data emitted via the `change` event
+  getValue: GetValue;
 
-```javascript
-<input
-  ...
-  dataReform={{
-    getValue: event => event.target.value.toUpperCase(),
-    validationRules: {
-      myRule1: control => !control.value
-    }
-  }}
-/>
+  // Use it to add Custom Validators either global or ad hoc
+  validationRules: {
+    [validationRuleName: string]: any;
+  };
+
+  // Use it to force Reform to treat a custom component as
+  // an input type such as a 'Radio'
+  inputType: string;
+
+  // Use it to pass data to your Custom Validators
+  params: any;
+}
 ```
+
+```typescript
+type GetValue = (first: Event | any, control: Control) => any
+```
+
 
 
 `getValue` is useful when you are trying to validate a custom component
@@ -476,11 +484,6 @@ invokes `onChange` with something else.
 This hooks let's you configure how Reform calculates the value of a given control
 from the onChange arguments.
 
-it's signature is:
-
-```typescript
-type GetValue = (first: Event | any, control: Control) => any
-```
 
 - `first` is an `event` for native `input` controls such as `input`, `select` and `textarea` but could also be anything that a Custom Control emits, such as a string, number, Date Object, Moment Object, Array, anything you can imagine. In fact, working with Custom Components is the main reason `getValue` exists.
 - `control` is the current state of the `control` so you have all the data of that control available such as the `inputType` for example.
@@ -500,6 +503,32 @@ You can force a Custom Component to be considered by `Reform` as a `checkbox` or
 
 > NOTE We already work well with `react-bootstrap` so no extra verbosity needed there. Also, the plan is to support
 any view libraries' Custom Components so PR us or create an issue for anything lacking.
+
+###### Example
+
+> In the following example we use it to tell Reform that it should validate
+this control with a custom ad hoc validator called `myRule1` and also we tell
+Reform that the value that this input emits on `change` should be calculated as
+`event.target.value.toUpperCase()`.
+We additionally use the `params` attribute to pass additional parameters to our custom Rule.
+This is very useful when used together with Global Validators because you can given them
+a generic form that accepts parameters.
+
+This gives you the flexibility to hook basically anything that has the three magical props:
+`name`, `value` and `onChange`.
+
+```javascript
+<input
+  ...
+  data-reform={{
+    getValue: event => event.target.value.toUpperCase(),
+    params: { name: 'Reform' },
+    validationRules: {
+      myRule1: control => control.value !== control.params.name
+    }
+  }}
+/>
+```
 
 ### Custom Validators
 > custom validators, validate, ad hoc, global validators, async validators

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ control = {
 Note that `errors.required` will be `false` because the control has a value so it's not in error state.
 
 ### `Form`
-> form state, formState, isValid, access to all controls
+> **Keywords:** form state, formState, isValid, access to all controls
 
 You can use this object to access all the controls in the form.
 You use typically use it to prevent the form from being submited if it's invalid
@@ -407,6 +407,8 @@ type Form = {
 ```
 
 
+<hr/>
+###### Example
 This is an example of how to check form validity before call to a hipotetical API submitting the form:
 
 ```javascript
@@ -434,7 +436,7 @@ class MyComponent extends React.Component {
   }
 }
 ```
-
+<hr/>
 
 ### `data-reform`
 > **Keywords:** configuration, config, manual, customization, custom validators, get value, parse
@@ -490,7 +492,7 @@ from the onChange arguments.
 
 You can force a Custom Component to be considered by `Reform` as a `checkbox` or a `radio` like this:
 
-```
+```javascript
 <MyCustomComponent
   name="myField"
   value={this.state.fields.myField}
@@ -498,6 +500,7 @@ You can force a Custom Component to be considered by `Reform` as a `checkbox` or
   data-reform={
     inputType:"checkbox"
   }
+/>
 ```
 
 > NOTE We already work well with `react-bootstrap` so no extra verbosity needed there. Also, the plan is to support

--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ type Errors = {
 };
 ```
 
-###### Example: what it looks like in practice
+
+###### :black_large_square: Example: what it looks like in practice
 ```javascript
 errors: {
   required: true,
@@ -280,7 +281,7 @@ errors: {
   :black_large_square:
 </h6>
 
-###### Example: errors and styling
+###### :black_large_square: Example: errors and styling
 
 Suppose our error state is initialized like this
 
@@ -364,7 +365,7 @@ The correct place to modify it is via `data-reform` and special props like nativ
 and the three magical `name`, `value`, `onChange`.
 
 
-###### Example
+###### :black_large_square: Example
 
 If you have a field like this
 ```javascript

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ class MyComponent extends React.Component {
 
 
 ### `data-reform`
-> **Keyword:** configuration, config, manual, customization, custom validators, get value, parse
+> **Keywords:** configuration, config, manual, customization, custom validators, get value, parse
 
 `data-reform` is a custom prop used to config reform on a particular form control.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Reform [![Build Status](https://travis-ci.org/franleplant/reform.svg?branch=master)](https://travis-ci.org/franleplant/reform) [![Coverage Status](https://coveralls.io/repos/github/franleplant/reform/badge.svg?branch=master)](https://coveralls.io/github/franleplant/reform?branch=master)
 
-Form validation library for react
-
+Form validation library for React
 
 > This lib is in Alpha stage
 
@@ -504,9 +503,10 @@ You can force a Custom Component to be considered by `Reform` as a `checkbox` or
 > NOTE We already work well with `react-bootstrap` so no extra verbosity needed there. Also, the plan is to support
 any view libraries' Custom Components so PR us or create an issue for anything lacking.
 
+<hr/>
 ###### Example
 
-> In the following example we use it to tell Reform that it should validate
+In the following example we use it to tell Reform that it should validate
 this control with a custom ad hoc validator called `myRule1` and also we tell
 Reform that the value that this input emits on `change` should be calculated as
 `event.target.value.toUpperCase()`.
@@ -529,6 +529,7 @@ This gives you the flexibility to hook basically anything that has the three mag
   }}
 />
 ```
+<hr/>
 
 ### Custom Validators
 > custom validators, validate, ad hoc, global validators, async validators

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ by version `4.2.4` in reform-examples
 - [Design Goals](#design-goals)
 - [Scope](#scope)
 - [Examples](#examples)
-- [API](#api)
+- [API](#api-docs)
   - [`<Reform/>`](#reform)
   - [`Errors`](#errors)
   - [`Control`](#contro)
@@ -208,12 +208,10 @@ is to provide as much freedom to you as you want to.
 
 For now, the examples are in a separate [Repo](https://github.com/franleplant/reform-examples) so you can also see them running, the repo it's versioned so if you look for Examples for Reform version 4.2.x you will see them tagged like 4.2.x too
 
-# Docs
+# API Docs
 > Documentation, docs
 
-## API
-
-### `<Reform/>`
+## `<Reform/>`
 > form, reform, component, entry point, onSubmit, top level api
 
 This is the entry point to the lib. The way to use it is as follow:
@@ -239,11 +237,13 @@ through `onSubmit` but you are free to do the way you want to.
 
 
 
-### `Errors`
+## `Errors`
+> **Keywords:** getErrorMap, display errors
 
-> getErrorMap, display errors
+
 Common interface for reporting errors for a particular `Control`.
 
+Type Definition
 ```typescript
 type Errors = {
   isValid: () => boolean;
@@ -258,11 +258,10 @@ type Errors = {
   // any custom validators you might be using.
   [validationRuleKey: string]: boolean;
 };
-
 ```
 
 <hr/>
-#### Example: what it looks like in practice
+###### Example: what it looks like in practice
 ```javascript
 errors: {
   required: true,
@@ -275,6 +274,8 @@ errors: {
 - each `validationRuleKey` is always related to a rule. So, for example, there's a rule (function) called `required` (built-in) which will be evaluated every time the input changes value and it's result will be stored in errors. 
 
 > Always `errors[validationRuleKey]` will be `true` if there is an **error**
+
+
 <hr/>
 
 <hr/>
@@ -311,7 +312,7 @@ See how useful the `isInvalid` attribute is, because it works well with empty ob
 
 <hr/>
 
-### `Control`
+## `Control`
 > **Keywords:** form control, form input, custom controls, field, input, select, textarea, radio, checkbox
 
 You access it from the `onChange` handlers like this:
@@ -392,7 +393,7 @@ control = {
 Note that `errors.required` will be `false` because the control has a value so it's not in error state.
 <hr/>
 
-### `Form`
+## `Form`
 > **Keywords:** form state, formState, isValid, access to all controls
 
 You can use this object to access all the controls in the form.
@@ -450,7 +451,7 @@ class MyComponent extends React.Component {
 ```
 <hr/>
 
-### `data-reform`
+## `data-reform`
 > **Keywords:** configuration, config, manual, customization, custom validators, get value, parse
 
 `data-reform` is a custom prop used to config reform on a particular form control.
@@ -546,8 +547,11 @@ This gives you the flexibility to hook basically anything that has the three mag
 ```
 <hr/>
 
-### Custom Validators
-> custom validators, validate, ad hoc, global validators, async validators
+## Custom Validators
+> **Keywords:** custom validators, validate, ad hoc, global validators, async validators
+
+
+
 
 > Async validators are not supported! They are planned but right now they complicate things too
 much, if you need to work with async validators you can use them directly with React, Reform wont 
@@ -557,13 +561,15 @@ Reform supports two forms of custom validators: Ad Hoc and Global.
 
 Validators are just functions with the following signature:
 
+Type Definition
 ```typescript
 CustomValidator: (control: Control, formState: FormState) => boolean;
 ```
 
 If a validator returns `true` then that means that there is an error.
 
-Example
+<hr/>
+###### Example
 
 ```javascript
 function customMinLength(control, formState) {
@@ -583,7 +589,10 @@ function customMinLength(control, formState) {
 > FormState gives you access to the rest of the form controls, so you can implement things such
 as password verification pretty easily
 
-#### Ad Hoc Custom Validators
+
+<hr/>
+
+### Ad Hoc Custom Validators
 
 This type of custom validators are defined in place of the control using it.
 They are similar to anonymous functions, they are intended for one time use.
@@ -619,7 +628,7 @@ like you will do with a regular function and use it ad hoc several times, you sh
 and use Global Validators instead.
 
 
-### Global Validators
+## Global Validators
 
 When building a big application you will probably want to create a reusable
 pool of Custom Validators that are related to your app's domain.

--- a/src/__tests__/params.js
+++ b/src/__tests__/params.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactTestUtils from 'react-addons-test-utils';
+import { shallow } from 'enzyme';
+import Reform, { Validators } from '../index';
+import { controlOnChangeTest, controlIntialStateTest } from '../testTemplates'
+
+
+
+Validators.addRule('myRule', control => control.value !== control.params.word);
+
+const name1 = "test_control_1";
+const name2 = "test_control_2";
+
+function render() {
+  const onChange = jest.fn();
+
+  const wrapper = shallow(
+    <Reform>
+      <form onSubmit={function() {}}>
+        <input
+          type="text"
+          name={name1}
+          value=""
+          onChange={onChange}
+          required
+          data-reform={{
+            params: {
+              word: 'Delfina',
+            },
+            validationRules: {
+              myRule: true
+            }
+          }}
+          />
+      </form>
+    </Reform>
+  );
+
+  return [wrapper, onChange];
+}
+
+describe('Custom Validations: Globals', () => {
+  describe('test case 1', () => {
+    describe('fail', () => {
+      const [wrapper, onChange] = render();
+      wrapper.find('input').simulate('change', {target: { value: '' }});
+
+      it('should call the original onChange handler', () => {
+        const [control] = onChange.mock.calls[0]
+        expect(onChange).toBeCalled()
+      })
+
+      it('should set error={myRule: true}', () => {
+        const [control] = onChange.mock.calls[0]
+        expect(control.errors.myRule).toBeDefined()
+        expect(control.errors.myRule).toBe(true)
+      })
+
+      it('should set error={required: true}', () => {
+        const [control] = onChange.mock.calls[0]
+        expect(control.errors.required).toBeDefined()
+        expect(control.errors.required).toBe(true)
+      })
+    })
+
+    describe('success', () => {
+      const [wrapper, onChange] = render();
+      wrapper.find('input').simulate('change', {target: { value: 'Delfina' }});
+
+      it('should call the original onChange handler', () => {
+        const [control] = onChange.mock.calls[0]
+        expect(onChange).toBeCalled()
+      })
+
+      it('should set error={myRule: true}', () => {
+        const [control] = onChange.mock.calls[0]
+        expect(control.errors.myRule).toBeDefined()
+        expect(control.errors.myRule).toBe(false)
+      })
+
+      it('should set error={required: true}', () => {
+        const [control] = onChange.mock.calls[0]
+        expect(control.errors.required).toBeDefined()
+        expect(control.errors.required).toBe(false)
+      })
+    })
+  })
+})
+

--- a/src/control.js
+++ b/src/control.js
@@ -13,9 +13,16 @@ interface ControlState {
   elementType: string | function,
   name: string,
   value: any,
-  inputType: string | void,
   errors: ReformErrors,
+  // Hackable
+  inputType: string | void,
+  // Hackable
   validationRules: ValidationRules
+  // Hackable
+  params: any;
+  // Hackable
+  getValue = Function;
+
 }
 
 */
@@ -71,7 +78,6 @@ export default class Control {
     let value = element.props.value
     //if it's a radio input then value should be set for the checked input if not it should be ''
     //warn user when not all radio buttons with the same name have the same validationRules
-    // TODO: from reform I need to check the correct value of the only checked radio button
     if (Element.isRadio(element)) {
       value = element.props.checked ? value : ''
     }
@@ -98,6 +104,8 @@ export default class Control {
     this.validationRules = mergeRulesSafely(Element.getValidationRules(element), config.validationRules);
     // Hackable
     this.getValue = config.getValue || defaultGetValue;
+    // Hackable
+    this.params = config.params;
 
     if (!this.name) {
       throw new Error(`All controlled inputs must have "name" props. In ${element}`)

--- a/src/index.js
+++ b/src/index.js
@@ -5,17 +5,6 @@ export default Reform;
 export { Validators };
 
 /*
-
-type GetValue = (event, control) => fieldValue
-
-interface ReformConfig {
-  validationRules: ValidationRules;
-  getValue: GetValue;
-  typeProp: string
-}
-*/
-
-/*
   form spec!
   https://www.w3.org/TR/html5/forms.html
 
@@ -23,14 +12,11 @@ interface ReformConfig {
   https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation
 */
 
-// TODO: docs! and examples!
 // TODO: example: dusplicate password input equality check
 // TODO: examples and checkboxes tests. Document the way to force something to be treated as a checkbox
 // TODO: support for asyn validators extra error details (say connection error et al). Probably a simple meta
 // field inside the control will suffice
-// TODO: error view helpers
 // TODO: test with bootstrap and other third party components
-// TODO: test bootstrap integration
 // TODO: warnings all over the place
 // TODO: warn if no form is in the children
 // TODO: warn if no controls


### PR DESCRIPTION
This fixes #4 and starts to lay the foundation for a better Documentation with a better formatting et al. 